### PR TITLE
VNDLY-31337: remove PyJWT constraint and remove deprecation warning

### DIFF
--- a/rest_framework_jwt/utils.py
+++ b/rest_framework_jwt/utils.py
@@ -33,11 +33,11 @@ def jwt_payload_handler(user):
     username_field = get_username_field()
     username = get_username(user)
 
-    warnings.warn(
-        'The following fields will be removed in the future: '
-        '`email` and `user_id`. ',
-        DeprecationWarning
-    )
+    # warnings.warn(
+    #     'The following fields will be removed in the future: '
+    #     '`email` and `user_id`. ',
+    #     DeprecationWarning
+    # )
 
     payload = {
         'user_id': user.pk,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ author = 'Jose Padilla'
 author_email = 'jpadilla@getblimp.com'
 license = 'MIT'
 install_requires = [
-    'PyJWT>=1.5.2,<2.0.0',
+    'PyJWT>=1.5.2',
 ]
 
 


### PR DESCRIPTION
This package was abandoned and has a constraint of <2.0.0 for PyJWT which is very old and prevents the upgrade of other packages.

Also hide DeprecationWarning cuz...no longer maintained.